### PR TITLE
Safely check for custom logs in mcMMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /dist/
+/nbproject/private/

--- a/src/com/thizthizzydizzy/treefeller/compat/McMMOCompat.java
+++ b/src/com/thizthizzydizzy/treefeller/compat/McMMOCompat.java
@@ -1,11 +1,11 @@
 package com.thizthizzydizzy.treefeller.compat;
 import com.thizthizzydizzy.simplegui.ItemBuilder;
-import com.thizthizzydizzy.treefeller.Modifier;
-import com.thizthizzydizzy.treefeller.OptionBoolean;
-import com.thizthizzydizzy.treefeller.Tool;
-import com.thizthizzydizzy.treefeller.Tree;
+import com.thizthizzydizzy.treefeller.*;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -22,6 +22,12 @@ public class McMMOCompat extends InternalCompatibility{
             return new ItemBuilder(Material.OAK_LOG).setCount(Objects.equals(value, true)?2:1);
         }
     };
+    private Logger logger;
+    @Override
+    public void init(TreeFeller treeFeller) {
+        super.init(treeFeller);
+        this.logger = treeFeller.getLogger();
+    }
     @Override
     public String getPluginName(){
         return "mcMMO";
@@ -33,12 +39,12 @@ public class McMMOCompat extends InternalCompatibility{
             com.gmail.nossr50.datatypes.player.McMMOPlayer mcmmoPlayer = com.gmail.nossr50.util.player.UserManager.getPlayer(player);
             com.gmail.nossr50.api.ExperienceAPI.addXpFromBlock(block.getState(), mcmmoPlayer);
             //canGetDoubleDrops and checkForDoubleDrop are private, so I'll just do it myself
-            if(com.gmail.nossr50.util.Permissions.isSubSkillEnabled(player, com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER)
-                    &&com.gmail.nossr50.util.skills.RankUtils.hasReachedRank(1, player, com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER)
-                    &&com.gmail.nossr50.util.random.ProbabilityUtil.isSkillRNGSuccessful(com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER, player)){
-                BlockState blockState = block.getState();
-                if(MCMMO_DOUBLE_DROPS.get(tool, tree)){
-                    if(com.gmail.nossr50.mcMMO.getModManager().isCustomLog(blockState) && com.gmail.nossr50.mcMMO.getModManager().getBlock(blockState).isDoubleDropEnabled()){
+            if(MCMMO_DOUBLE_DROPS.get(tool, tree)){
+                if(com.gmail.nossr50.util.Permissions.isSubSkillEnabled(player, com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER)
+                        &&com.gmail.nossr50.util.skills.RankUtils.hasReachedRank(1, player, com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER)
+                        &&com.gmail.nossr50.util.random.ProbabilityUtil.isSkillRNGSuccessful(com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER, com.gmail.nossr50.util.player.UserManager.getPlayer(player))){
+                    BlockState blockState = block.getState();
+                    if(isCustomLogWithDoubleDropEnabled(blockState)){
                         modifiers.add(new Modifier(Modifier.Type.LOG_MULT, 2));
                     }else{
                         if(com.gmail.nossr50.mcMMO.p.getGeneralConfig().getWoodcuttingDoubleDropsEnabled(blockState.getBlockData())){
@@ -48,5 +54,26 @@ public class McMMOCompat extends InternalCompatibility{
                 }
             }
         }catch(Exception ex){}
+    }
+    public boolean isCustomLogWithDoubleDropEnabled(BlockState blockState){
+        try{
+            Class<?> modManagerClass = Class.forName("com.gmail.nossr50.util.ModManager");
+            Object modManagerInstance = modManagerClass
+                    .getMethod("getModManager")
+                    .invoke(null);
+            Object mcMmoBlock = modManagerClass
+                    .getMethod("getBlock", BlockState.class)
+                    .invoke(modManagerInstance, blockState);
+            boolean isCustomLog = (Boolean) Class.forName("com.gmail.nossr50.util.ModManager")
+                    .getMethod("isCustomLog", BlockState.class)
+                    .invoke(modManagerInstance, blockState);
+            boolean isDoubleDropEnabled = (Boolean) mcMmoBlock.getClass()
+                    .getMethod("isDoubleDropEnabled")
+                    .invoke(mcMmoBlock);
+            return isCustomLog && isDoubleDropEnabled;
+        }catch(NoSuchMethodError | ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e){
+            logger.log(Level.FINE, "Unable to check for custom blocks in mcMMO.", e);
+            return false;
+        }
     }
 }

--- a/src/com/thizthizzydizzy/treefeller/compat/McMMOCompat.java
+++ b/src/com/thizthizzydizzy/treefeller/compat/McMMOCompat.java
@@ -42,7 +42,7 @@ public class McMMOCompat extends InternalCompatibility{
             if(MCMMO_DOUBLE_DROPS.get(tool, tree)){
                 if(com.gmail.nossr50.util.Permissions.isSubSkillEnabled(player, com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER)
                         &&com.gmail.nossr50.util.skills.RankUtils.hasReachedRank(1, player, com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER)
-                        &&com.gmail.nossr50.util.random.ProbabilityUtil.isSkillRNGSuccessful(com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER, com.gmail.nossr50.util.player.UserManager.getPlayer(player))){
+                        &&com.gmail.nossr50.util.random.ProbabilityUtil.isSkillRNGSuccessful(com.gmail.nossr50.datatypes.skills.SubSkillType.WOODCUTTING_HARVEST_LUMBER, player)){
                     BlockState blockState = block.getState();
                     if(isCustomLogWithDoubleDropEnabled(blockState)){
                         modifiers.add(new Modifier(Modifier.Type.LOG_MULT, 2));


### PR DESCRIPTION
It seems like mcMMO is removing the internal `ModManager` class along with custom blocks. I'm not sure if it's going to be replaced in the future, but right now, Tree Feller attempting to access its methods breaks mcMMO compatibility.

This PR updates the logic to use reflection to obtain a `ModManager` instance and more gracefully fall back to assuming the block isn't custom if the needed methods don't exist, allowing for double drops to work for normal blocks.

I also moved the `MCMMO_DOUBLE_DROPS` check up so Tree Feller doesn't run the permissions checks when it doesn't need to.

Note: I wasn't really sure how to build this, since I'm not familiar with the Ant build system, and where to source some of the plugin libraries, so I haven't tested to see if it works.